### PR TITLE
Prevented systemd unit file from being deleted.

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -7,7 +7,7 @@ module.exports = function (root, pkg) {
   var specsDirectory = files.specsDirectory(root);
   var sourcesDirectory = files.sourcesDirectory(root);
 
-  rimraf.sync(serviceFilePath);
+  // rimraf.sync(serviceFilePath);
   rimraf.sync(specsDirectory);
   rimraf.sync(sourcesDirectory);
 };

--- a/lib/serviceProperties.js
+++ b/lib/serviceProperties.js
@@ -9,7 +9,7 @@ function getEnvironment(pkg) {
 }
 
 function getInstallDir(pkg) {
-  return _.get(pkg, 'spec.installDir', '/opt');
+  return _.get(pkg, 'spec.installDir', '/opt/' + pkg.name);
 }
 
 module.exports = function (pkg) {

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -26,7 +26,7 @@ function getNoArch(pkg) {
 }
 
 function getInstallDir(pkg) {
-  return _.get(pkg, 'spec.installDir', '/opt');
+  return _.get(pkg, 'spec.installDir', '/opt/' + pkg.name);
 }
 
 function getNodeVersion(pkg) {
@@ -36,7 +36,7 @@ function getNodeVersion(pkg) {
 function getExecutableFiles(pkg) {
   var name = pkg.name;
   var executableFiles = _.get(pkg, 'spec.executable', []).map(function (file) {
-    return path.join(getInstallDir(pkg), name, file);
+    return path.join(getInstallDir(pkg), file);
   });
 
   return {

--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -54,11 +54,11 @@ npm rebuild
 
 %pre
 getent group {{username}} >/dev/null || groupadd -r {{username}}
-getent passwd {{username}} >/dev/null || useradd -r -g {{username}} -G {{username}} -d / -s /sbin/nologin -c "{{username}}" {{username}}
+getent passwd {{username}} >/dev/null || useradd -r -g {{username}} -G {{username}} -d / -s /sbin/nologin {{username}}
 
 %install
-mkdir -p %{buildroot}{{installDir}}/{{name}}
-cp -r ./* %{buildroot}{{installDir}}/{{name}}
+mkdir -p %{buildroot}{{installDir}}
+cp -r ./* %{buildroot}{{installDir}}
 
 %post
 {{#postInstallCommands}}

--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -14,7 +14,6 @@ Release: %{release}
 {{/dist}}
 Summary: {{name}}
 
-Group: Installation Script
 License: {{license}}
 Source: %{name}.tar.gz
 BuildRoot: %{buildroot}

--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -70,7 +70,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(644, {{username}}, {{username}}, 755)
-{{installDir}}/{{name}}
+{{installDir}}
 {{#hasExecutableFiles}}
 %defattr(755, {{username}}, {{username}}, 755)
 {{#executableFiles}}


### PR DESCRIPTION
Removed need to specify //{{name}} in %install spec.mustache by modifying default installDir to be '/opt/' + pkg.name instead of just '/opt'.
Removed /{{name}} from %install in spec.mustache.
Prevented {{#executableFiles}} from appending {{name}} in spec.mustache.  It now uses installDir.
Removed superfluous comment from useradd in spec.mustache.